### PR TITLE
Add border to color swatches

### DIFF
--- a/src/ColorList.tsx
+++ b/src/ColorList.tsx
@@ -19,6 +19,8 @@ const ColorBoxContainer = styled.div`
 `
 
 const ColorBox = styled.div`
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 1px var(--card-shadow-outline-color);
   content: '';
   position: absolute;
   inset: 0;


### PR DESCRIPTION
This PR adds a border to the color list swatches introduced in the last version to make white on white distinguishable, for example.

<img width="431" alt="Bildschirmfoto 2023-05-15 um 11 56 31" src="https://github.com/sanity-io/color-input/assets/360736/31023562-1226-4ae1-80f3-32b67aa7cfea">
