### PR TITLE
fix: show presence and validation indication

### DIFF
--- a/src/ColorInput.js
+++ b/src/ColorInput.js
@@ -39,6 +39,8 @@ export default class ColorInput extends PureComponent {
       hex: PropTypes.string,
       alpha: PropTypes.number,
     }),
+    markers: PropTypes.array,
+    presence: PropTypes.array,
   }
 
   focus() {
@@ -85,9 +87,15 @@ export default class ColorInput extends PureComponent {
   }
 
   render() {
-    const {type, readOnly, value, level} = this.props
+    const {type, readOnly, value, level, markers, presence} = this.props
     return (
-      <FormField title={type.title} description={type.description} level={level}>
+      <FormField
+        title={type.title}
+        description={type.description}
+        level={level}
+        __unstable_markers={markers}
+        __unstable_presence={presence}
+      >
         {value ? (
           <ColorPicker
             ref={this.focusRef}


### PR DESCRIPTION
Seems like the color input in studio v2 never had presence or validation indication. I'm not quite sure if presence actually flows through due to focus broadcasting and subfields, but I don't think it is critical - the most important thing is to indicate validation errors.

Sidenote: v3 ❤️