### PR TITLE
fix: display HSL correctly

### DIFF
--- a/src/ColorPicker.tsx
+++ b/src/ColorPicker.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {Alpha, Checkboard, Hue, Saturation} from 'react-color/lib/components/common'
 import {Color, CustomPicker} from 'react-color'
 import {Box, Button, Card, Flex, Inline, Stack, Text} from '@sanity/ui'
@@ -111,8 +110,8 @@ const ColorPickerInner = (props: ColorPickerProps) => {
                         {rgb?.r} {rgb?.g} {rgb?.b}
                       </Text>
                       <Text size={1}>
-                        <strong>HSL: </strong> {Math.round(hsl?.h ?? 0)} {Math.round(hsl?.s ?? 0)}%{' '}
-                        {Math.round(hsl?.l ?? 0)}
+                        <strong>HSL: </strong> {Math.round(hsl?.h ?? 0)}{' '}
+                        {Math.round((hsl?.s ?? 0) * 100)}% {Math.round((hsl?.l ?? 0) * 100)}%
                       </Text>
                     </Inline>
                   </Stack>


### PR DESCRIPTION
### **Title:**  
**Fix incorrect Saturation and Lightness values in read-only mode for HSL display**

### **Description:**
This PR fixes a bug where the Saturation and Lightness values were not displayed correctly in read-only mode. While the Hue value was correct, the Saturation and Lightness were displayed as 0 or 1 instead of percentages.
This happened because Saturation and Lightness values are stored as numbers between 0 and 1, and the UI was rounding these values directly, which resulted in them being displayed as either 0 or 1. By multiplying the values by 100 before being rounded, they are now correctly displayed as percentages.

### **Changes:**
- Updated the logic to properly multiply the Saturation and Lightness values by 100 to convert them to percentages.
- Added % after Lightness value

Before:
<img width="633" alt="image" src="https://github.com/user-attachments/assets/0c11ffcc-1a89-4654-8263-57db9a700d6f">

After:
<img width="623" alt="image" src="https://github.com/user-attachments/assets/dda90638-eef4-4de3-9d30-3f87f7c87f3b">

example data:
```
  "gradientEndColor": {
    "_type": "color",
    "alpha": 1,
    "hex": "#396d88",
    "hsl": {
      "_type": "hslaColor",
      "a": 1,
      "h": 199.99999999999997,
      "l": 0.3777998,
      "s": 0.4081532070689291
    },
    "hsv": {
      "_type": "hsvaColor",
      "a": 1,
      "h": 199.99999999999997,
      "s": 0.5797,
      "v": 0.532
    },
    "rgb": {
      "_type": "rgbaColor",
      "a": 1,
      "b": 136,
      "g": 109,
      "r": 57
    }
  },
  ```