### PR TITLE
fix(ColorPicker): explicitly provide default props to Checkboard component

### DIFF
--- a/src/ColorPicker.tsx
+++ b/src/ColorPicker.tsx
@@ -86,7 +86,12 @@ const ColorPickerInner = (props: ColorPickerProps) => {
               overflow="hidden"
               style={{position: 'relative', minWidth: '4em', background: '#fff'}}
             >
-              <Checkboard />
+              <Checkboard
+                size={8}
+                white="transparent"
+                grey="rgba(0,0,0,.08)"
+                renderers={{} as {canvas: unknown}}
+              />
               <ColorBox
                 style={{
                   backgroundColor: `rgba(${rgb?.r},${rgb?.g},${rgb?.b},${rgb?.a})`,


### PR DESCRIPTION
### Title:
Fix `react-color` Checkboard Component's Outdated `defaultProps`

### Description:

Default props in functional components were [removed](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops) in React 19. This PR adjusts the `Checkboard` component’s usage to prevent issues arising from this change.

Solves #76.

### Changes

- Provides explicit `size`, `white`, and `grey` props to specify the `Checkboard` component's appearance.
- Adds type casting to `unknown` for compatibility.