### PR TITLE
fix(deps): allow studio v4 in peer dep ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
       },
       "peerDependencies": {
         "react": "^18.3 || ^19",
-        "sanity": "^3.23.0",
+        "sanity": "^3.23.0 || ^4.0.0-0",
         "styled-components": "^6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
   },
   "browserslist": "extends @sanity/browserslist-config",
   "prettier": "@sanity/prettier-config",
+  "overrides": {
+    "conventional-changelog-conventionalcommits": ">= 8.0.0"
+  },
   "dependencies": {
     "@sanity/icons": "^3.5.3",
     "@sanity/incompatible-plugin": "^1.0.5",
@@ -90,7 +93,7 @@
   },
   "peerDependencies": {
     "react": "^18.3 || ^19",
-    "sanity": "^3.23.0",
+    "sanity": "^3.23.0 || ^4.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {
@@ -98,9 +101,6 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "overrides": {
-    "conventional-changelog-conventionalcommits": ">= 8.0.0"
   },
   "sanityExchangeUrl": "https://www.sanity.io/plugins/color-input"
 }


### PR DESCRIPTION
### Description

Prepping for July 15th: https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason#299526b398ec

Currently when using a package.json like: 
```json
{
  "dependencies": {
    "sanity": "4.0.0-0"
  }
}
```
Running `pnpm install --resolution-only` yields peer dep issues:
```bash
❯ pnpm install --resolution-only --ignore-workspace
Progress: resolved 1033, reused 0, downloaded 0, added 0, done
 WARN  Issues with peer dependencies found
.
└─┬ @sanity/color-input 4.0.3
  └── ✕ unmet peer sanity@^3.23.0: found 4.0.0-0
Done in 1.5s using pnpm v10.12.1
```
This fixes it.

### Testing

Tested locally
